### PR TITLE
Api changes for multilevel successor options

### DIFF
--- a/simpleoptions/option.py
+++ b/simpleoptions/option.py
@@ -25,12 +25,13 @@ class BaseOption(ABC):
         pass
 
     @abstractmethod
-    def policy(self, state: Hashable) -> Hashable:
+    def policy(self, state: Hashable, test: bool = False) -> Hashable:
         """
         Returns the action specified by this option's policy for a given state.
 
         Arguments:
             state {Hashable} -- The environmental state in which the option chooses an action in.
+            test [bool] --  When True the option follows a greedy-policy, for evaluation. Defaults to False.
 
         Returns:
             action [Hashable] -- The action specified by the option's policy in this state.

--- a/simpleoptions/options_agent.py
+++ b/simpleoptions/options_agent.py
@@ -56,7 +56,11 @@ class OptionAgent:
         self.test_env = test_env if test_env is not None else None
 
     def macro_q_learn(
-        self, state_trajectory: List[Hashable], rewards: List[float], option: "BaseOption", n_step=False
+        self,
+        state_trajectory: List[Hashable],
+        rewards: List[float],
+        option: "BaseOption",
+        n_step=False,
     ) -> None:
         """
         Performs Macro Q-Learning updates along the given trajectory for the given Option.
@@ -79,7 +83,9 @@ class OptionAgent:
                     f"Option {option.hierarchy_level}-{option.source_cluster}->{option.target_cluster} ran for {len(state_trajectory)} decision stages.\n"
                 )
                 # Write the q-values in the state it got stuck in.
-                most_common_state = max(set(state_trajectory), key=state_trajectory.count)
+                most_common_state = max(
+                    set(state_trajectory), key=state_trajectory.count
+                )
                 q_values = {
                     str(o): option.q_table.get((hash(most_common_state), hash(o)), 0)
                     for o in self.env.get_available_options(most_common_state)
@@ -109,8 +115,12 @@ class OptionAgent:
                 q_values = [0]
 
             # Perform Macro-Q Update
-            self.q_table[(hash(initiation_state), hash(option))] = old_value + self.macro_q_alpha * (
-                discounted_sum_of_rewards + math.pow(self.gamma, len(rewards)) * max(q_values) - old_value
+            self.q_table[
+                (hash(initiation_state), hash(option))
+            ] = old_value + self.macro_q_alpha * (
+                discounted_sum_of_rewards
+                + math.pow(self.gamma, len(rewards)) * max(q_values)
+                - old_value
             )
 
             state_trajectory.pop(0)
@@ -151,36 +161,51 @@ class OptionAgent:
             # We perform an intra-option update for all other options which select executed_option in this state.
             for other_option in self.env.get_available_options(initiation_state):
                 if (
-                    (hash(other_option) != hash(higher_level_option) or higher_level_option is None)
+                    (
+                        hash(other_option) != hash(higher_level_option)
+                        or higher_level_option is None
+                    )
                     and other_option.initiation(initiation_state)
-                    and hash(other_option.policy(initiation_state)) == hash(executed_option)
+                    and hash(other_option.policy(initiation_state))
+                    == hash(executed_option)
                 ):
-                    old_value = self.q_table[(hash(initiation_state), hash(other_option))]
+                    old_value = self.q_table[
+                        (hash(initiation_state), hash(other_option))
+                    ]
 
                     # Compute discounted sum of rewards.
-                    discounted_sum_of_rewards = self._discounted_return(rewards, self.gamma)
+                    discounted_sum_of_rewards = self._discounted_return(
+                        rewards, self.gamma
+                    )
 
                     if not self.env.is_state_terminal(termination_state):
                         # If the option terminates, we consider the value of the next best option.
-                        next_q_terminates = other_option.termination(termination_state) * max(
+                        next_q_terminates = other_option.termination(
+                            termination_state
+                        ) * max(
                             [
                                 self.q_table[(hash(termination_state), hash(o))]
-                                for o in self.env.get_available_options(termination_state)
+                                for o in self.env.get_available_options(
+                                    termination_state
+                                )
                             ]
                         )
                         # If the option continues, we consider the value of the currently executing option.
-                        next_q_continues = (1 - other_option.termination(termination_state)) * self.q_table[
-                            (hash(termination_state), hash(other_option))
-                        ]
+                        next_q_continues = (
+                            1 - other_option.termination(termination_state)
+                        ) * self.q_table[(hash(termination_state), hash(other_option))]
 
                     else:
                         next_q_terminates = 0
                         next_q_continues = 0
 
                     # Perform Intra-Option Update.
-                    self.q_table[(hash(initiation_state), hash(other_option))] = old_value + self.intra_option_alpha * (
+                    self.q_table[
+                        (hash(initiation_state), hash(other_option))
+                    ] = old_value + self.intra_option_alpha * (
                         discounted_sum_of_rewards
-                        + math.pow(self.gamma, len(rewards)) * (next_q_continues + next_q_terminates)
+                        + math.pow(self.gamma, len(rewards))
+                        * (next_q_continues + next_q_terminates)
                         - old_value
                     )
 
@@ -212,24 +237,41 @@ class OptionAgent:
         if len(executing_options) == 0:
             # Random Action.
             if not test and random.random() < self.epsilon:
-                available_options = self.env.get_available_options(state, exploration=True)
+                available_options = self.env.get_available_options(
+                    state, exploration=True
+                )
                 return random.choice(available_options)
             # Best Action.
             else:
-                available_options = self.env.get_available_options(state, exploration=False)
+                available_options = self.env.get_available_options(
+                    state, exploration=False
+                )
                 # Find Q-values of available options.
-                q_values = [self.q_table[(hash(state), hash(o))] for o in available_options]
+                q_values = [
+                    self.q_table[(hash(state), hash(o))] for o in available_options
+                ]
 
                 # Return the option with the highest Q-value, breaking ties randomly.
                 return available_options[
-                    random.choice([idx for idx, q_value in enumerate(q_values) if q_value == max(q_values)])
+                    random.choice(
+                        [
+                            idx
+                            for idx, q_value in enumerate(q_values)
+                            if q_value == max(q_values)
+                        ]
+                    )
                 ]
         # If we are currently following an option's policy, return what it selects.
         else:
-            return executing_options[-1].policy(state)
+            return executing_options[-1].policy(state, test)
 
     def run_agent(
-        self, num_epochs, epoch_length, render_interval: int = 0, test_interval: int = 0, test_length: int = 0
+        self,
+        num_epochs,
+        epoch_length,
+        render_interval: int = 0,
+        test_interval: int = 0,
+        test_length: int = 0,
     ) -> List[float]:
         """
         Trains the agent for a given number of episodes.
@@ -301,8 +343,13 @@ class OptionAgent:
                         self.executing_options_rewards[i].append(reward)
 
                     # Terminate any options which need terminating this time-step.
-                    while self.executing_options and self._roll_termination(self.executing_options[-1], next_state):
-                        if self.executing_options[-1] not in self.env.exploration_options:
+                    while self.executing_options and self._roll_termination(
+                        self.executing_options[-1], next_state
+                    ):
+                        if (
+                            self.executing_options[-1]
+                            not in self.env.exploration_options
+                        ):
                             # Perform a macro-q learning update for the terminating option.
                             self.macro_q_learn(
                                 self.executing_options_states[-1],
@@ -315,7 +362,9 @@ class OptionAgent:
                                 self.executing_options_states[-1],
                                 self.executing_options_rewards[-1],
                                 self.executing_options[-1],
-                                self.executing_options[-2] if len(self.executing_options) > 1 else None,
+                                self.executing_options[-2]
+                                if len(self.executing_options) > 1
+                                else None,
                                 self.n_step_updates,
                             )
                         self.executing_options_states.pop()
@@ -334,7 +383,10 @@ class OptionAgent:
                 # Handle if the current state is terminal.
                 if terminal:
                     while len(self.executing_options) > 0:
-                        if self.executing_options[-1] not in self.env.exploration_options:
+                        if (
+                            self.executing_options[-1]
+                            not in self.env.exploration_options
+                        ):
                             # Perform a macro-q learning update for the topmost option.
                             self.macro_q_learn(
                                 self.executing_options_states[-1],
@@ -347,7 +399,9 @@ class OptionAgent:
                                 self.executing_options_states[-1],
                                 self.executing_options_rewards[-1],
                                 self.executing_options[-1],
-                                self.executing_options[-2] if len(self.executing_options) > 1 else None,
+                                self.executing_options[-2]
+                                if len(self.executing_options) > 1
+                                else None,
                                 self.n_step_updates,
                             )
                         self.executing_options_states.pop()
@@ -376,7 +430,9 @@ class OptionAgent:
                 terminal = False
 
                 while not terminal:
-                    selected_option = self.select_action(state, executing_options, test=not allow_exploration)
+                    selected_option = self.select_action(
+                        state, executing_options, test=not allow_exploration
+                    )
 
                     # Handle if the selected option is a higher-level option.
                     if isinstance(selected_option, BaseOption):
@@ -385,13 +441,17 @@ class OptionAgent:
                     # Handle if the selected option is a primitive action.
                     else:
                         time_steps += 1
-                        next_state, reward, terminal, __ = self.test_env.step(selected_option)
+                        next_state, reward, terminal, __ = self.test_env.step(
+                            selected_option
+                        )
 
                         state = deepcopy(next_state)
                         run_rewards.append(reward)
 
                         # Terminate any options which need terminating this time-step.
-                        while executing_options and self._roll_termination(executing_options[-1], next_state):
+                        while executing_options and self._roll_termination(
+                            executing_options[-1], next_state
+                        ):
                             executing_options.pop()
 
                     # If we have been testing for more than the desired number of time-steps, terminate.

--- a/simpleoptions/primitive_option.py
+++ b/simpleoptions/primitive_option.py
@@ -29,7 +29,7 @@ class PrimitiveOption(BaseOption):
     def initiation(self, state: Hashable) -> bool:
         return self.action in self.env.get_available_actions(state)
 
-    def policy(self, state: Hashable) -> Hashable:
+    def policy(self, state: Hashable, test: bool = False) -> Hashable:
         return self.action
 
     def termination(self, state: Hashable) -> float:

--- a/simpleoptions/primitive_option.py
+++ b/simpleoptions/primitive_option.py
@@ -12,6 +12,10 @@ class PrimitiveOption(BaseOption):
     primitive actions are available.
     """
 
+    # work around that fixes issues with Dill load (specifically overloading hash) \
+    # https://stackoverflow.com/questions/75409930/pickle-and-dill-cant-load-objects-with-overridden-hash-function-attributee
+    action = ""
+
     def __init__(self, action: Hashable, env: "BaseEnvironment"):
         """Constructs a new primitive option.
 

--- a/test/test_intra_option_update.py
+++ b/test/test_intra_option_update.py
@@ -25,7 +25,7 @@ class DummyOption(BaseOption):
     def initiation(self, state):
         return True
 
-    def policy(self, state, test):
+    def policy(self, state, test=False):
         return self.action
 
     def termination(self, state):

--- a/test/test_intra_option_update.py
+++ b/test/test_intra_option_update.py
@@ -1,6 +1,12 @@
 import pytest
 
-from simpleoptions import OptionAgent, BaseOption, PrimitiveOption, option, primitive_option
+from simpleoptions import (
+    OptionAgent,
+    BaseOption,
+    PrimitiveOption,
+    option,
+    primitive_option,
+)
 
 
 class DummyOption(BaseOption):
@@ -19,7 +25,7 @@ class DummyOption(BaseOption):
     def initiation(self, state):
         return True
 
-    def policy(self, state):
+    def policy(self, state, test):
         return self.action
 
     def termination(self, state):
@@ -69,16 +75,25 @@ def test_one_step_intra_option_update_1():
     option_2 = DummyOption("test_option_2", lower_level_option, "state_2")
 
     # Initialise an OptionAgent (note that initial q-values for all states are zero by default).
-    agent = OptionAgent(env=DummyEnv([option_1, option_2, lower_level_option]), macro_alpha=alpha, gamma=gamma)
+    agent = OptionAgent(
+        env=DummyEnv([option_1, option_2, lower_level_option]),
+        macro_alpha=alpha,
+        gamma=gamma,
+    )
 
     # First, perform a macro-q update for option_1. Then, perform an intra-option update for
     # option_1. This should result in both option_1 and option_2 having the same q-value in
     # state_1, since they both execute the same primitive action, and should both get updated once.
     agent.macro_q_learn(state_trajectory, reward_trajectory, option_1, n_step=True)
-    agent.intra_option_learn(state_trajectory, reward_trajectory, lower_level_option, option_1, n_step=True)
+    agent.intra_option_learn(
+        state_trajectory, reward_trajectory, lower_level_option, option_1, n_step=True
+    )
 
     # Ensure that the q-values for executing option_1 in state_1 and executing option_2 in state_1 are the same.
-    assert agent.q_table[(hash("state_1"), hash(option_1))] == agent.q_table[(hash("state_1"), hash(option_2))]
+    assert (
+        agent.q_table[(hash("state_1"), hash(option_1))]
+        == agent.q_table[(hash("state_1"), hash(option_2))]
+    )
 
 
 # Two options which execute the different primitive actions, one time-step, initial q-values of zero.
@@ -99,7 +114,9 @@ def test_one_step_intra_option_update_2():
 
     # Initialise an OptionAgent (note that initial q-values for all states are zero by default).
     agent = OptionAgent(
-        env=DummyEnv([option_1, option_2, lower_level_option_1, lower_level_option_2]), macro_alpha=alpha, gamma=gamma
+        env=DummyEnv([option_1, option_2, lower_level_option_1, lower_level_option_2]),
+        macro_alpha=alpha,
+        gamma=gamma,
     )
 
     # First, perform a macro-q update for option_1. Then, perform an intra-option update for
@@ -107,7 +124,9 @@ def test_one_step_intra_option_update_2():
     # macro-q update), but option_2 should not be updated during the intra-option update because
     # its policy is different to option_1's.
     agent.macro_q_learn(state_trajectory, reward_trajectory, option_1, n_step=True)
-    agent.intra_option_learn(state_trajectory, reward_trajectory, lower_level_option_1, option_1, n_step=True)
+    agent.intra_option_learn(
+        state_trajectory, reward_trajectory, lower_level_option_1, option_1, n_step=True
+    )
 
     # Ensure that the q-value of executing option_1 in state_1 is updated, and that the
     # q-value of executing option_2 in state_1 remains at 0.0.

--- a/test/test_macro_q_update.py
+++ b/test/test_macro_q_update.py
@@ -20,7 +20,7 @@ class DummyOption(BaseOption):
     def initiation(self, state):
         return True
 
-    def policy(self, state):
+    def policy(self, state, test):
         return 1
 
     def termination(self, state):
@@ -68,8 +68,12 @@ def test_one_step_macro_q_update_1():
     # Ensure that the new value of initating our test option in state_1 is correct after performing the update.
     # Our dummy environment returns a list containing the primitive action 1 as the available action in state_2,
     # and its value will be zero (we assume that this is the first update, and initial q-valaues are zero by default).
-    assert agent.q_table[(hash("state_1"), hash(option))] == initial_values["state_1, option"] + alpha * (
-        reward_trajectory[0] + gamma * initial_values["state_2, 1"] - initial_values["state_1, option"]
+    assert agent.q_table[(hash("state_1"), hash(option))] == initial_values[
+        "state_1, option"
+    ] + alpha * (
+        reward_trajectory[0]
+        + gamma * initial_values["state_2, 1"]
+        - initial_values["state_1, option"]
     )
 
 
@@ -96,8 +100,12 @@ def test_one_step_macro_q_update_2():
     # 1 was earned after transitioning from state_1 to state_2.
     agent.macro_q_learn(state_trajectory, reward_trajectory, option, n_step=True)
 
-    assert agent.q_table[(hash("state_1"), hash(option))] == initial_values["state_1, option"] + alpha * (
-        reward_trajectory[0] + gamma * initial_values["state_2, 1"] - initial_values["state_1, option"]
+    assert agent.q_table[(hash("state_1"), hash(option))] == initial_values[
+        "state_1, option"
+    ] + alpha * (
+        reward_trajectory[0]
+        + gamma * initial_values["state_2, 1"]
+        - initial_values["state_1, option"]
     )
 
 
@@ -107,7 +115,12 @@ def test_three_step_macro_q_update_1():
     state_trajectory = ["state_1", "state_2", "state_3", "state_4"]
     reward_trajectory = [2, 3, 4]
     option = DummyOption("test_option_1")
-    initial_values = {"state_1, option": 0, "state_2, option": 0, "state_3, option": 0, "state_4, 1": 0}
+    initial_values = {
+        "state_1, option": 0,
+        "state_2, option": 0,
+        "state_3, option": 0,
+        "state_4, 1": 0,
+    }
     alpha = 0.2
     gamma = 0.9
 
@@ -120,7 +133,9 @@ def test_three_step_macro_q_update_1():
     agent.macro_q_learn(state_trajectory, reward_trajectory, option, n_step=True)
 
     # Ensure that the value of executing our test option in state_1 has been updated correctly.
-    assert agent.q_table[(hash("state_1"), hash(option))] == initial_values["state_1, option"] + alpha * (
+    assert agent.q_table[(hash("state_1"), hash(option))] == initial_values[
+        "state_1, option"
+    ] + alpha * (
         reward_trajectory[0]
         + gamma**1 * reward_trajectory[1]
         + gamma**2 * reward_trajectory[2]
@@ -129,7 +144,9 @@ def test_three_step_macro_q_update_1():
     )
 
     # Ensure that the value of executing our test option in state_2 has been updated correctly.
-    assert agent.q_table[(hash("state_2"), hash(option))] == initial_values["state_1, option"] + alpha * (
+    assert agent.q_table[(hash("state_2"), hash(option))] == initial_values[
+        "state_1, option"
+    ] + alpha * (
         reward_trajectory[1]
         + gamma**1 * reward_trajectory[2]
         + gamma**2 * initial_values["state_4, 1"]
@@ -137,8 +154,12 @@ def test_three_step_macro_q_update_1():
     )
 
     # Ensure that the value of executing our test option in state_3 has been updated correctly.
-    assert agent.q_table[(hash("state_3"), hash(option))] == initial_values["state_1, option"] + alpha * (
-        reward_trajectory[2] + gamma**1 * initial_values["state_4, 1"] - initial_values["state_3, option"]
+    assert agent.q_table[(hash("state_3"), hash(option))] == initial_values[
+        "state_1, option"
+    ] + alpha * (
+        reward_trajectory[2]
+        + gamma**1 * initial_values["state_4, 1"]
+        - initial_values["state_3, option"]
     )
 
 
@@ -148,7 +169,12 @@ def test_three_step_macro_q_update_2():
     state_trajectory = ["state_1", "state_2", "state_3", "state_4"]
     reward_trajectory = [2, 3, 4]
     option = DummyOption("test_option_1")
-    initial_values = {"state_1, option": 4, "state_2, option": 5, "state_3, option": 6, "state_4, 1": 7}
+    initial_values = {
+        "state_1, option": 4,
+        "state_2, option": 5,
+        "state_3, option": 6,
+        "state_4, 1": 7,
+    }
     alpha = 0.2
     gamma = 0.9
 
@@ -168,7 +194,9 @@ def test_three_step_macro_q_update_2():
     agent.macro_q_learn(state_trajectory, reward_trajectory, option, n_step=True)
 
     # Ensure that the value of executing our test option in state_1 has been updated correctly.
-    assert agent.q_table[(hash("state_1"), hash(option))] == initial_values["state_1, option"] + alpha * (
+    assert agent.q_table[(hash("state_1"), hash(option))] == initial_values[
+        "state_1, option"
+    ] + alpha * (
         reward_trajectory[0]
         + gamma**1 * reward_trajectory[1]
         + gamma**2 * reward_trajectory[2]
@@ -177,7 +205,9 @@ def test_three_step_macro_q_update_2():
     )
 
     # Ensure that the value of executing our test option in state_2 has been updated correctly.
-    assert agent.q_table[(hash("state_2"), hash(option))] == initial_values["state_2, option"] + alpha * (
+    assert agent.q_table[(hash("state_2"), hash(option))] == initial_values[
+        "state_2, option"
+    ] + alpha * (
         reward_trajectory[1]
         + gamma**1 * reward_trajectory[2]
         + gamma**2 * initial_values["state_4, 1"]
@@ -185,6 +215,10 @@ def test_three_step_macro_q_update_2():
     )
 
     # Ensure that the value of executing our test option in state_3 has been updated correctly.
-    assert agent.q_table[(hash("state_3"), hash(option))] == initial_values["state_3, option"] + alpha * (
-        reward_trajectory[2] + gamma**1 * initial_values["state_4, 1"] - initial_values["state_3, option"]
+    assert agent.q_table[(hash("state_3"), hash(option))] == initial_values[
+        "state_3, option"
+    ] + alpha * (
+        reward_trajectory[2]
+        + gamma**1 * initial_values["state_4, 1"]
+        - initial_values["state_3, option"]
     )

--- a/test/test_macro_q_update.py
+++ b/test/test_macro_q_update.py
@@ -20,7 +20,7 @@ class DummyOption(BaseOption):
     def initiation(self, state):
         return True
 
-    def policy(self, state, test):
+    def policy(self, state, test = False):
         return 1
 
     def termination(self, state):


### PR DESCRIPTION
An option policy can now be called as either greedy or epsilon-greedy by passing a boolean argument.
Workaround to PrimitiveOption that fixes issues with Dill save/load, caused by __hash__