### PR TITLE
Added Support for Multiple Evaluation Options

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setuptools.setup(
     name="simpleoptions",
-    version="0.9.1",
+    version="0.10.0",
     author="Joshua Evans",
     author_email="jbe25@bath.ac.uk",
     description="A simple and flexible framework for working with Options in Reinforcement Learning.",

--- a/simpleoptions/options_agent.py
+++ b/simpleoptions/options_agent.py
@@ -30,7 +30,7 @@ class OptionAgent:
         gamma: float = 1.0,
         default_action_value=0.0,
         n_step_updates=False,
-        rng: RNG = None,
+        rng: "RNG" = None,
         *args,
         **kwargs,
     ):
@@ -240,7 +240,7 @@ class OptionAgent:
         verbose_logging: bool = True,
         epoch_eval: bool = False,
         episodic_eval: bool = False,
-    ) -> Tuple[DefaultDict, DefaultDict | None]:
+    ) -> Tuple[DefaultDict, DefaultDict, DefaultDict | List[float], List[float], List[float]]:
         """
         Trains the agent for a given number of epochs.
 

--- a/test/test_run_agent.py
+++ b/test/test_run_agent.py
@@ -702,14 +702,20 @@ def test_training_rewards_length():
     agent.q_table[(hash(1), hash(hlo1))] = initial_higher_level_option_q_value
 
     # Run the agent for five time-steps (i.e., until it reaches the terminal state).
-    training_rewards, _ = agent.run_agent(
-        num_epochs=1, epoch_length=5, test_interval=1, test_length=5, verbose_logging=False
+    training_rewards = agent.run_agent(
+        num_epochs=1,
+        epoch_length=5,
+        test_interval=1,
+        test_length=5,
+        epoch_eval=False,
+        episodic_eval=False,
+        verbose_logging=False,
     )
 
     assert len(training_rewards) == 1
 
 
-def test_evaluation_rewards_length():
+def test_epoch_evaluation_rewards_length():
     epsilon = 0.0
     macro_alpha = 0.5
     intra_option_alpha = 0.5
@@ -741,7 +747,57 @@ def test_evaluation_rewards_length():
     agent.q_table[(hash(1), hash(hlo1))] = initial_higher_level_option_q_value
 
     # Run the agent for five time-steps (i.e., until it reaches the terminal state).
-    _, testing_rewards = agent.run_agent(
-        num_epochs=1, epoch_length=5, test_interval=1, test_length=5, verbose_logging=False
+    _, epoch_testing_rewards = agent.run_agent(
+        num_epochs=1,
+        epoch_length=5,
+        test_interval=1,
+        test_length=5,
+        epoch_eval=True,
+        episodic_eval=False,
+        verbose_logging=False,
     )
-    assert len(testing_rewards) == 1
+    assert len(epoch_testing_rewards) == 1
+
+
+def test_episodic_evaluation_rewards_length():
+    epsilon = 0.0
+    macro_alpha = 0.5
+    intra_option_alpha = 0.5
+    gamma = 0.9
+    default_action_value = 0.0
+    initial_higher_level_option_q_value = 1.0
+
+    # Initialise env and add the dummy options to the list of available options.
+    env = DummyEnv()
+    test_env = DummyEnv()
+    llo1 = DummyLowerLevelOption(1, 1)
+    llo2 = DummyLowerLevelOption(2, 1)
+    hlo1 = DummyHigherLevelOption(1, llo1)
+    env.set_options([llo1, llo2, hlo1])
+    test_env.set_options([llo1, llo2, hlo1])
+
+    # Initialise agent and set the q-value of the higher-level option to 1.0 in the initial
+    # state, to ensure that it is always chosen (notice that we have disabled exploration).
+    agent = OptionAgent(
+        env=env,
+        test_env=test_env,
+        epsilon=epsilon,
+        macro_alpha=macro_alpha,
+        intra_option_alpha=intra_option_alpha,
+        gamma=gamma,
+        n_step_updates=False,
+        default_action_value=default_action_value,
+    )
+    agent.q_table[(hash(1), hash(hlo1))] = initial_higher_level_option_q_value
+
+    # Run the agent for five time-steps (i.e., until it reaches the terminal state).
+    _, episodic_testing_rewards = agent.run_agent(
+        num_epochs=1,
+        epoch_length=5,
+        test_interval=1,
+        test_length=5,
+        epoch_eval=False,
+        episodic_eval=True,
+        verbose_logging=False,
+    )
+    assert len(episodic_testing_rewards) == 1


### PR DESCRIPTION
- `OptionAgent.run_agent` now allows episodic and epoch-based evaluation to be performed in a single run.
- Training performance is always returned. If `epoch_eval` is true, epoch-based evaluation is performed and returned. If `episodic_eval` is true, episodic evaluation is performed and returned.